### PR TITLE
fix(containers.md): adding cornercase for non-standard mount points

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -137,7 +137,11 @@ for Apptainer/Singularity, or
 ```
 export GAMMAPY_KERNEL_IMAGE="docker_username/gammapy_tools:latest"
 ```
-for Docker.
+for Docker. Additionally for Docker, you must set the `GAMMAPY_WORK_DIR` environmental variable:
+```
+export GAMMAPY_WORK_DIR=/path/to/working/directory
+```
+This is needed for Docker, as, by default, no directories will be mounted within the container. Whereas Apptainer/Singularity will, by default (unless your sysadmin installed it differently), will have access to [a set of commonly used directories](https://apptainer.org/docs/user/main/bind_paths_and_mounts.html#system-defined-bind-paths). If you're using a location not bound by default, then you'll also need to set the `GAMMAPY_WORK_DIR` environmental variable when working with Apptainer/Singularity.
 
 Launch a Jupyter instances as you normally do from any envrionment. When creating a new notebook you'll now see the option to use the containerized `gammapy-kernel`.
 

--- a/launch_kernel_apptainer.sh
+++ b/launch_kernel_apptainer.sh
@@ -11,7 +11,7 @@ else
     # if it isn't start an instance
     echo "Starting the server"
     # Bind the runtime-dir (where the connection files are) to /connections within the container
-    apptainer instance start --bind `jupyter --runtime-dir`:/connections $image_name $container_name
+    apptainer instance start --bind $GAMMAPY_WORK_DIR:$GAMMAPY_WORK_DIR --bind `jupyter --runtime-dir`:/connections $image_name $container_name
 fi
 
 # Attach and run ipykernel_laucher

--- a/launch_kernel_docker.sh
+++ b/launch_kernel_docker.sh
@@ -18,7 +18,7 @@ else
     docker rm $container_name
     # Create a new container
     # Add it to the host network and mounting the connection_path
-    docker create --name=$container_name -v  $connection_path:/connections --network=host  $image_name
+    docker create --name=$container_name -v $GAMMAPY_WORK_DIR:$GAMMAPY_WORK_DIR -v  $connection_path:/connections --network=host  $image_name
     # Start this server instance
     docker start  $container_name
 fi


### PR DESCRIPTION
Adding a volume path for docker and catching the corner case for `/` binds which might not be caught by apptainer's defaults.